### PR TITLE
Replace missing commands

### DIFF
--- a/modules/ch2-configure/pages/s2-webapp-lab.adoc
+++ b/modules/ch2-configure/pages/s2-webapp-lab.adoc
@@ -241,7 +241,7 @@ It is expected that applications which fail to run on confined domains from syst
 +
 [source,subs="verbatim,quotes"]
 --
-$ *getseboolean -a | grep httpd*
+$ *semanage boolean --list | grep httpd*
 ...
 httpd_can_network_connect --> off
 httpd_can_network_connect_cobbler --> off
@@ -254,9 +254,9 @@ httpd_can_network_memcache --> off
 +
 [source,subs="verbatim,quotes"]
 --
-$ *sudo setsebool httpd_can_network_connect_db on*
-$ *getsebool httpd_can_network_connect_db*
-httpd_can_network_connect_db --> on
+$ *sudo semanage boolean --modify httpd_can_network_connect_db --on*
+$ *sudo semanage boolean --list | grep httpd_can_network_connect_db*
+httpd_can_network_connect_db   (on   ,   on)  Allow httpd to can network connect db
 --
 +
 6.3. Revisit the "random quote" page. It should now work:

--- a/modules/ch3-policy/pages/s3-interfaces.adoc
+++ b/modules/ch3-policy/pages/s3-interfaces.adoc
@@ -28,7 +28,7 @@ You can use the suggestion from the `audit2allow` command as a starting point: r
 
 == Expanding Interfaces Into Allow Statements
 
-If the comments in an interface file are not clear to you, or you wish to double-check exactly which permissions you get from an interface, you can use the `macro-expand` command, from the `selinux-policy-devel` package, to expand an interface into its policy statements.
+If the comments in an interface file are not clear to you, or you wish to double-check exactly which permissions you get from an interface, you can use the `macro-expander` command, from the `selinux-policy-devel` package, to expand an interface into its policy statements.
 
 You give the `macro-expander` a complete reference to an interface, including all arguments. It outputs the list of allow rules that the interface generates.
 


### PR DESCRIPTION
'getseboolean', 'setsebool', 'getsebool' are not provided by any package in RHEL 9.5. 'macro-expand' exists as 'macro-expander'.

I didn't check when these were introduced/old ones removed, the docs might need to be updated to reflect that.